### PR TITLE
Update Windows_Dropbox_InstanceDB.smap

### DIFF
--- a/SQLMap/Maps/Windows_Dropbox_InstanceDB.smap
+++ b/SQLMap/Maps/Windows_Dropbox_InstanceDB.smap
@@ -9,7 +9,7 @@ IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='
 IdentifyValue: 1
 Queries:
     -
-        Name: Drobpox
+        Name: Dropbox
         Query: |
                 SELECT
                 id,


### PR DESCRIPTION
Small typo fix

## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [NA ] I have generated a unique `GUID` for my Map(s)
- [X ] I have tested and validated that the new Map(s) work with test data and achieved the desired output
- [X ] I have placed the Map(s) within the `.\SQLECmd\SQLMap\Maps` directory
- [NA ] I have set or updated the version of my Map(s)
- [ NA] I have made an attempt to document the artifacts within the Map(s)
- [NA ] I have consulted the [Guide](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.guide)/[Template](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
