### PR TITLE
Replaced table name typed_url_sync_metadata with keyword_search_terms

### DIFF
--- a/SQLMap/Maps/Windows_ChromiumBrowser_Downloads.smap
+++ b/SQLMap/Maps/Windows_ChromiumBrowser_Downloads.smap
@@ -2,7 +2,7 @@ Description: Chromium Browser Downloads
 Author: Andrew Rathbun
 Email: andrew.rathbun@kroll.com
 Id: 0b575bcf-ade3-44e5-8162-eb52a96c2b06
-Version: 1.0
+Version: 1.1
 CSVPrefix: ChromiumBrowser
 FileName: History
 IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='urls' OR name='visits' OR name='downloads' OR name='segments' OR name='keyword_search_terms');

--- a/SQLMap/Maps/Windows_ChromiumBrowser_Downloads.smap
+++ b/SQLMap/Maps/Windows_ChromiumBrowser_Downloads.smap
@@ -5,7 +5,7 @@ Id: 0b575bcf-ade3-44e5-8162-eb52a96c2b06
 Version: 1.0
 CSVPrefix: ChromiumBrowser
 FileName: History
-IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='urls' OR name='visits' OR name='downloads' OR name='segments' OR name='typed_url_sync_metadata');
+IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='urls' OR name='visits' OR name='downloads' OR name='segments' OR name='keyword_search_terms');
 IdentifyValue: 5
 Queries:
     -

--- a/SQLMap/Maps/Windows_ChromiumBrowser_HistoryVisits.smap
+++ b/SQLMap/Maps/Windows_ChromiumBrowser_HistoryVisits.smap
@@ -5,7 +5,7 @@ Id: 1f37cc07-2b10-4c80-b845-84708e4f7429
 Version: 1.1
 CSVPrefix: ChromiumBrowser
 FileName: History
-IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='urls' OR name='visits' OR name='downloads' OR name='segments' OR name='typed_url_sync_metadata');
+IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='urls' OR name='visits' OR name='downloads' OR name='segments' OR name='keyword_search_terms');
 IdentifyValue: 5
 Queries:
     -

--- a/SQLMap/Maps/Windows_ChromiumBrowser_HistoryVisits.smap
+++ b/SQLMap/Maps/Windows_ChromiumBrowser_HistoryVisits.smap
@@ -2,7 +2,7 @@ Description: Chromium Browser History Visits
 Author: Andrew Rathbun
 Email: andrew.rathbun@kroll.com
 Id: 1f37cc07-2b10-4c80-b845-84708e4f7429
-Version: 1.1
+Version: 1.2
 CSVPrefix: ChromiumBrowser
 FileName: History
 IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='urls' OR name='visits' OR name='downloads' OR name='segments' OR name='keyword_search_terms');

--- a/SQLMap/Maps/Windows_ChromiumBrowser_KeywordSearches.smap
+++ b/SQLMap/Maps/Windows_ChromiumBrowser_KeywordSearches.smap
@@ -5,7 +5,7 @@ Id: d968ece4-d24a-4baf-8f07-78da07727712
 Version: 1.0
 CSVPrefix: ChromiumBrowser
 FileName: History
-IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='urls' OR name='visits' OR name='downloads' OR name='segments' OR name='typed_url_sync_metadata');
+IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='urls' OR name='visits' OR name='downloads' OR name='segments' OR name='keyword_search_terms');
 IdentifyValue: 5
 Queries:
     -

--- a/SQLMap/Maps/Windows_ChromiumBrowser_KeywordSearches.smap
+++ b/SQLMap/Maps/Windows_ChromiumBrowser_KeywordSearches.smap
@@ -2,7 +2,7 @@ Description: Chromium Browser Keyword Searches
 Author: Andrew Rathbun
 Email: andrew.rathbun@kroll.com
 Id: d968ece4-d24a-4baf-8f07-78da07727712
-Version: 1.0
+Version: 1.1
 CSVPrefix: ChromiumBrowser
 FileName: History
 IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='urls' OR name='visits' OR name='downloads' OR name='segments' OR name='keyword_search_terms');


### PR DESCRIPTION
## Description

Replaced table name "typed_url_sync_metadata" with "keyword_search_terms" in relevant Chromium maps.
Updated map version numbers.

September 15th, the table "typed_url_sync_metadata" was removed from Chromium
https://chromium.googlesource.com/chromium/src/+/85f25aa0c7cd3b0f8becceec9509349e188dc4a3
https://chromium-review.googlesource.com/c/chromium/src/+/4859451

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [ ] I have generated a unique `GUID` for my Map(s)
- [x] I have tested and validated that the new Map(s) work with test data and achieved the desired output
- [x] I have placed the Map(s) within the `.\SQLECmd\SQLMap\Maps` directory
- [x] I have set or updated the version of my Map(s)
- [ ] I have made an attempt to document the artifacts within the Map(s)
- [x] I have consulted the [Guide](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.guide)/[Template](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
