### PR TITLE
Added smap For Idrive SQLite Database

### DIFF
--- a/SQLMap/Maps/Windows_Idrive_FileBackup.smap
+++ b/SQLMap/Maps/Windows_Idrive_FileBackup.smap
@@ -1,0 +1,38 @@
+Description: Idrive Backups
+Author: Thomas Burnette
+Email: thomas.burnette@cox.com
+Id: 35e1ef80-0311-4eb7-8b18-724aa572ae46
+Version: 1.0
+CSVPrefix: Idrive
+FileName: random.db # run --hunt mode on the directory to make use of this map
+IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='ibfile');
+IdentifyValue: 1
+Queries:
+    -
+        Name: Files
+        Query: |
+                SELECT
+                    ibfolder.NAME
+                AS
+                    'file_directory',
+                    ibfile.NAME
+                AS
+                    'filen_name',
+                    ibfile.FILE_SIZE
+                AS
+                    'file_size',
+                    ibfile.FILE_LMD
+                AS
+                    'file_modify_date'
+                FROM
+                    ibfile
+                INNER JOIN
+                    ibfolder
+                ON
+                    ibfile.DIRID = ibfolder.DIRID;
+        BaseFileName: BackupFiles
+
+# Documentation
+# https://www.idrive.com/
+# IDrive provides Online cloud Backup for PCs, Macs, iPhones, Android and other Mobile Devices.
+# Sqlite database that contains the file name, directory, and file size of files that are backed up from a local drive.


### PR DESCRIPTION
Added a new smap for Idrive related SQLite databases which record a list of files on local drives that are currently backed up.

## Description

- smap to complement new Idrive Kape target in https://github.com/EricZimmerman/KapeFiles/pull/915

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [x] I have generated a unique `GUID` for my Map(s)
- [x] I have tested and validated that the new Map(s) work with test data and achieved the desired output
- [x] I have placed the Map(s) within the `.\SQLECmd\SQLMap\Maps` directory
- [x] I have set or updated the version of my Map(s)
- [x] I have made an attempt to document the artifacts within the Map(s)
- [x] I have consulted the [Guide](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.guide)/[Template](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
