### PR TITLE
Added smap for Edge Browser Collections, a bookmarks-like feature uni…

### DIFF
--- a/SQLMap/Maps/Windows_EdgeBrowser_Collections.smap
+++ b/SQLMap/Maps/Windows_EdgeBrowser_Collections.smap
@@ -14,7 +14,7 @@ Queries:
         Query: |
                 SELECT
                 /* Collections table */
-                datetime(collections.date_created/1000, 'unixepoch', 'utc') AS Collection_CreationUTC, 
+                datetime(collections.date_created/1000, 'unixepoch', 'utc') AS Collection_CreationUTC,
                 datetime(collections.date_modified/1000, 'unixepoch', 'utc') AS Collection_ModifiedUTC,
                 collections.title as Collection_Title,
                 collections.position as Collection_Position,
@@ -37,7 +37,7 @@ Queries:
                 case when items.type == "website"
                     then datetime(items.date_created, 'unixepoch', 'utc')
                     else datetime(items.date_created/1000, 'unixepoch', 'utc')
-                end AS Item_CreationUTC, 
+                end AS Item_CreationUTC,
                 datetime(items.date_modified/1000, 'unixepoch', 'utc') AS Item_ModifiedUTC,
                 cast(items.source as varchar) AS Item_Source,
                 items.Title AS Item_Title,
@@ -50,11 +50,11 @@ Queries:
                 items.type AS Item_Type,
                 items.tag AS Item_Tag,
 
-                /* Items Offline Data */ 
+                /* Items Offline Data */
                 items_offline_data.offline_file_data AS Item_OfflineFileData,
 
                 /* Items_Sync Data */
-                datetime(items_sync.date_last_synced/1000, 'unixepoch', 'utc') AS ItemSync_DateLastSynced, 
+                datetime(items_sync.date_last_synced/1000, 'unixepoch', 'utc') AS ItemSync_DateLastSynced,
                 items_sync.is_syncable AS ItemSync_IsSyncable,
 
                 /* Comments table */
@@ -73,10 +73,10 @@ Queries:
 
 
                 FROM
-                items 
-                    left join collections_items_relationship 
+                items
+                    left join collections_items_relationship
                         on items.id = collections_items_relationship.item_id
-                    left join collections 
+                    left join collections
                         on collections_items_relationship.parent_id = collections.id
                     left join collections_sync
                         on collections.id = collections_sync.collection_id
@@ -87,8 +87,8 @@ Queries:
                     left join items_sync
                         on items.id = items_sync.item_id
 
-                ORDER BY 
-                    Collection_Title ASC, items.date_created DESC 
+                ORDER BY
+                    Collection_Title ASC, items.date_created DESC
         BaseFileName: Collections
 
 # Documentation


### PR DESCRIPTION
Added smap for Edge Browser Collections, a bookmarks-like feature unique to MS Edge

## Description

Added file \SQLMap\Maps\Windows_EdgeBrowser_Collections.smap. This parses Microsoft Edge's "collectionsSQLite" file which contains forensically useful information on a subject's browser activity. Collections in Edge can be used alongside or in place of Favorites (Bookmarks), and notes / comments can be added inline with saved entries.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [x] I have generated a unique `GUID` for my Map(s)
- [x] I have tested and validated that the new Map(s) work with test data and achieved the desired output
- [x] I have placed the Map(s) within the `.\SQLECmd\SQLMap\Maps` directory
- [x] I have set or updated the version of my Map(s)
- [x] I have made an attempt to document the artifacts within the Map(s)
- [x] I have consulted the [Guide](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.guide)/[Template](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
