### PR TITLE
Update Windows_SimpleStickyNotes_NotesDB.smap

### DIFF
--- a/SQLMap/Maps/Windows_SimpleStickyNotes_NotesDB.smap
+++ b/SQLMap/Maps/Windows_SimpleStickyNotes_NotesDB.smap
@@ -13,7 +13,7 @@ Queries:
         Name: Simple Sticky Notes DB
         Query: |
                SELECT
-                 NOTEBOOKS.ID,
+                 COALESCE(NOTEBOOKS.ID, NOTES.ID) AS ID,
                  NOTEBOOKS.NAME,
                  NOTES.STATE,
                  datetime((NOTES.CREATED - 25569) * 86400, 'unixepoch', 'localtime', 'utc') AS CREATED_UTC,
@@ -54,14 +54,14 @@ Queries:
                  NOTES.ALARM_DAY,
                  NOTES.ALARM_SNOOZE,
                  NOTES.ALARM_SOUND,
-                 NOTES.NOTEBOOK,
+                 NOTEBOOKS.NAME AS NotebookName,
                  NOTES.TITLE,
                  NOTES.TYPE,
                  NOTES.DATA,
                  NOTES.TEXT
                FROM
-                 NOTEBOOKS
-                 LEFT JOIN NOTES ON NOTEBOOKS.ID = NOTES.ID
+                 NOTES
+                 LEFT JOIN NOTEBOOKS ON NOTEBOOKS.ID = NOTES.ID;
         BaseFileName: NotesDB
 
 # Documentation


### PR DESCRIPTION
fix to make sure it is pulling everything from NOTES and resolving with NOTEBOOKS

## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [x] I have generated a unique `GUID` for my Map(s)
- [x] I have tested and validated that the new Map(s) work with test data and achieved the desired output
- [x] I have placed the Map(s) within the `.\SQLECmd\SQLMap\Maps` directory
- [x] I have set or updated the version of my Map(s)
- [x] I have made an attempt to document the artifacts within the Map(s)
- [x] I have consulted the [Guide](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.guide)/[Template](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
