### PR TITLE
Fix SQLMap issue on .NET 9 and fix compile errors on Linux

### DIFF
--- a/SQLECmd/Program.cs
+++ b/SQLECmd/Program.cs
@@ -12,7 +12,7 @@ using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
 #if NET6_0_OR_GREATER
-using System.RuntimeInformation.InteropServices;
+using System.Runtime.InteropServices;
 #endif
 using CsvHelper;
 using Exceptionless;

--- a/SQLECmd/Program.cs
+++ b/SQLECmd/Program.cs
@@ -439,6 +439,9 @@ internal class Program
         {
             //32 Bit Not Tested on Linux
             //File.WriteAllBytes(sqllitefile, Resources.x86SQLite_Interop_linux);
+            Log.Warning("32 Bit Linux Not Supported! Exiting");
+            Console.WriteLine();
+            Environment.Exit(-1);
         }
         } else {
 

--- a/SQLECmd/Program.cs
+++ b/SQLECmd/Program.cs
@@ -11,6 +11,9 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
+#if NET6_0_OR_GREATER
+using System.RuntimeInformation.InteropServices;
+#endif
 using CsvHelper;
 using Exceptionless;
 using ICSharpCode.SharpZipLib.Zip;
@@ -355,6 +358,39 @@ internal class Program
 
         Console.WriteLine();
 
+#if NET6_0_OR_GREATER
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)){ 
+        if (!File.Exists("libSQLite.Interop.so"))
+        {
+            return;
+        }
+
+        try
+        {
+            File.Delete("libSQLite.Interop.so");
+        }
+        catch (Exception)
+        {
+            Log.Warning("Unable to delete {File}. Delete manually if needed", "libSQLite.Interop.so");
+            Console.WriteLine();
+        }
+        } else {
+            if (!File.Exists("SQLite.Interop.dll"))
+        {
+            return;
+        }
+
+        try
+        {
+            File.Delete("SQLite.Interop.dll");
+        }
+        catch (Exception)
+        {
+            Log.Warning("Unable to delete {File}. Delete manually if needed", "SQLite.Interop.dll");
+            Console.WriteLine();
+        }
+        }
+#else
         if (!File.Exists("SQLite.Interop.dll"))
         {
             return;
@@ -369,6 +405,7 @@ internal class Program
             Log.Warning("Unable to delete {File}. Delete manually if needed", "SQLite.Interop.dll");
             Console.WriteLine();
         }
+#endif        
     }
 
     private static void DumpUnmatched(string unmatchedDb)
@@ -390,6 +427,21 @@ internal class Program
 
     private static void DumpSqliteDll()
     {
+#if NET6_0_OR_GREATER
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)){
+        var sqllitefile = "libSQLite.Interop.so"; 
+
+        if (Environment.Is64BitProcess)
+        {
+            File.WriteAllBytes(sqllitefile, Resources.x64SQLite_Interop_linux);
+        }
+        else
+        {
+            //32 Bit Not Tested on Linux
+            //File.WriteAllBytes(sqllitefile, Resources.x86SQLite_Interop_linux);
+        }
+        } else {
+
         var sqllitefile = "SQLite.Interop.dll";
 
         if (Environment.Is64BitProcess)
@@ -400,6 +452,19 @@ internal class Program
         {
             File.WriteAllBytes(sqllitefile, Resources.x86SQLite_Interop);
         }
+        }
+#else               
+        var sqllitefile = "SQLite.Interop.dll";
+
+        if (Environment.Is64BitProcess)
+        {
+            File.WriteAllBytes(sqllitefile, Resources.x64SQLite_Interop);
+        }
+        else
+        {
+            File.WriteAllBytes(sqllitefile, Resources.x86SQLite_Interop);
+        }
+#endif        
     }
 
     private static void ProcessFile(string fileName, bool hunt, bool dedupe, string csv)

--- a/SQLECmd/Properties/Resources.Designer.cs
+++ b/SQLECmd/Properties/Resources.Designer.cs
@@ -79,5 +79,15 @@ namespace SQLECmd.Properties {
                 return ((byte[])(obj));
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
+        internal static byte[] x64SQLite_Interop_linux {
+            get {
+                object obj = ResourceManager.GetObject("x64SQLite_Interop_linux", resourceCulture);
+                return ((byte[])(obj));
+            }
+        }
     }
 }

--- a/SQLECmd/Properties/Resources.resx
+++ b/SQLECmd/Properties/Resources.resx
@@ -124,4 +124,7 @@
   <data name="x86SQLite_Interop" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Dependencies\x86\SQLite.Interop.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+    <data name="x64SQLite_Interop_linux" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Dependencies\x64\libSQLite.Interop.so;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/SQLECmd/Properties/Resources.resx
+++ b/SQLECmd/Properties/Resources.resx
@@ -119,9 +119,9 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="x64SQLite_Interop" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>Dependencies\x64\SQLite.Interop.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\Dependencies\x64\SQLite.Interop.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="x86SQLite_Interop" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>Dependencies\x86\SQLite.Interop.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\Dependencies\x86\SQLite.Interop.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/SQLMap.Test/SQLMap.Test.csproj
+++ b/SQLMap.Test/SQLMap.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <Version>0.6.0</Version>
         <LangVersion>10</LangVersion>
         <IsPackable>false</IsPackable>

--- a/SQLMap/SQLMap.cs
+++ b/SQLMap/SQLMap.cs
@@ -56,7 +56,7 @@ public class SqlMap
 
         IEnumerable<string> files;
 
-#if !NET6_0
+#if !NET6_0_OR_GREATER
   var f = new Alphaleonis.Win32.Filesystem.DirectoryEnumerationFilters
         {
             InclusionFilter = entry => entry.Extension.ToUpperInvariant() == ".SMAP",

--- a/SQLMap/SQLMaps.csproj
+++ b/SQLMap/SQLMaps.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
         <LangVersion>10</LangVersion>
         <Version>0.6.0</Version>
         <Authors>Eric R. Zimmerman</Authors>


### PR DESCRIPTION
## Description

This allows SQLECmd to compile on Linux and paired with the SQLMap fix in this pull request and a modified libSQLite.Interop.so allows Linux to run SQLECmd without errors 😍. This is Part 1 of the pull request as I need to test a clean way to integrate the libSQLite.Interop.so file and add instructions for compiling it. Linux does not like the Resources.resx missing the ..\ so test if this is still happy on Windows as I really don't want to install the bloated mess that is Visual Studio ATM to check that. 

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [ ] I have generated a unique `GUID` for my Map(s)
- [ ] I have tested and validated that the new Map(s) work with test data and achieved the desired output
- [ ] I have placed the Map(s) within the `.\SQLECmd\SQLMap\Maps` directory
- [ ] I have set or updated the version of my Map(s)
- [ ] I have made an attempt to document the artifacts within the Map(s)
- [ ] I have consulted the [Guide](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.guide)/[Template](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
