### PR TITLE
GitHub Action to Compile Linux SQLite on Demand

### DIFF
--- a/.github/workflows/build_linux_sqlite_interop.yml
+++ b/.github/workflows/build_linux_sqlite_interop.yml
@@ -1,0 +1,30 @@
+name: Download and Compile SQLite Interop Assembly Linux
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Download SQLite source
+      run: wget https://system.data.sqlite.org/blobs/1.0.119.0/sqlite-netFx-full-source-1.0.119.0.zip
+
+    - name: Unzip SQLite source
+      run: unzip sqlite-netFx-full-source-1.0.119.0.zip
+
+    - name: Grant execute permissions
+      run: chmod +x Setup/compile-interop-assembly-release.sh
+
+    - name: Run compile script
+      run: Setup/compile-interop-assembly-release.sh
+
+    - name: Upload compiled library
+      uses: actions/upload-artifact@v4
+      with:
+        name: libSQLite.Interop.so
+        path: bin/2013/Release/bin/libSQLite.Interop.so


### PR DESCRIPTION
## Description

In order to make your life easier when compiling the Linux libSQLite.Interop.so file I created this GitHub Action that you can run on demand which compiles the correct file for you.

@EricZimmerman or @AndrewRathbun after this is merged can you please run it from the actions tab, download the compiled file and put it in the SQLECmd/Dependencies/x64 folder

Thanks!

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [ ] I have generated a unique `GUID` for my Map(s)
- [ ] I have tested and validated that the new Map(s) work with test data and achieved the desired output
- [ ] I have placed the Map(s) within the `.\SQLECmd\SQLMap\Maps` directory
- [ ] I have set or updated the version of my Map(s)
- [ ] I have made an attempt to document the artifacts within the Map(s)
- [ ] I have consulted the [Guide](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.guide)/[Template](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
