### PR TITLE
Fix Chromium TopSites Map

### DIFF
--- a/SQLMap/Maps/Windows_ChromiumBrowser_TopSites.smap
+++ b/SQLMap/Maps/Windows_ChromiumBrowser_TopSites.smap
@@ -2,7 +2,7 @@ Description: Chromium Browser Top Sites
 Author: Andrew Rathbun
 Email: andrew.d.rathbun@gmail.com
 Id: 3b2fc9c8-23ea-4694-82a2-266aa819db3b
-Version: 1.0
+Version: 1.1
 CSVPrefix: ChromiumBrowser
 FileName: Top Sites
 IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='meta' OR name='top_sites');
@@ -14,8 +14,7 @@ Queries:
                 SELECT
                 top_sites.url_rank AS URLRank,
                 top_sites.url AS URL,
-                top_sites.title AS Title,
-                top_sites.redirects AS Redirects
+                top_sites.title AS Title
                 FROM
                 top_sites
                 ORDER BY


### PR DESCRIPTION
## Description
Chromium has seemingly stopped using the redirects field. See commit [b82f4e7](https://source.chromium.org/chromium/chromium/src/+/b82f4e7340de0f4de19eb670ce71c621b3e5fc89). Without dropping this field it returns an error as redirects no longer exists in the database table. Tested on Edge and Brave Browser
## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Map(s)
- [X] I have tested and validated that the new Map(s) work with test data and achieved the desired output
- [X] I have placed the Map(s) within the `.\SQLECmd\SQLMap\Maps` directory
- [X] I have set or updated the version of my Map(s)
- [X] I have made an attempt to document the artifacts within the Map(s)
- [X] I have consulted the [Guide](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.guide)/[Template](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
