### PR TITLE
Fixes FileName Case Sensitivity

### DIFF
--- a/SQLECmd/Program.cs
+++ b/SQLECmd/Program.cs
@@ -294,7 +294,7 @@ internal class Program
             var enumerationOptions = new EnumerationOptions
             {
                 IgnoreInaccessible = true,
-                MatchCasing = MatchCasing.CaseSensitive,
+                MatchCasing = MatchCasing.CaseInsensitive,
                 RecurseSubdirectories = true,
                 AttributesToSkip = 0
             };


### PR DESCRIPTION
## Description

Fixes #77. Tested on Linux and Windows .NET 9 and works well

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [ ] I have generated a unique `GUID` for my Map(s)
- [ ] I have tested and validated that the new Map(s) work with test data and achieved the desired output
- [ ] I have placed the Map(s) within the `.\SQLECmd\SQLMap\Maps` directory
- [ ] I have set or updated the version of my Map(s)
- [ ] I have made an attempt to document the artifacts within the Map(s)
- [ ] I have consulted the [Guide](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.guide)/[Template](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
