### PR TITLE
Make Chromium Timestamps UTC

### DIFF
--- a/SQLMap/Maps/Windows_ChromiumBrowser_Cookies.smap
+++ b/SQLMap/Maps/Windows_ChromiumBrowser_Cookies.smap
@@ -2,7 +2,7 @@ Description: Chromium Browser Cookies
 Author: Andrew Rathbun
 Email: andrew.d.rathbun@gmail.com
 Id: e1849119-3265-4880-a45e-a6029757625d
-Version: 1.0
+Version: 1.1
 CSVPrefix: ChromiumBrowser
 FileName: Cookies
 IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='cookies' OR name='meta');
@@ -12,9 +12,9 @@ Queries:
         Name: Chromium Browser Cookies
         Query: |
                 SELECT
-                datetime ( cookies.creation_utc / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch', 'localtime' ) AS CreationUTC,
-                datetime ( cookies.expires_utc / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch', 'localtime' ) AS ExpiresUTC,
-                datetime ( cookies.last_access_utc / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch', 'localtime' ) AS LastAccessUTC,
+                datetime ( cookies.creation_utc / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch' ) AS CreationUTC,
+                datetime ( cookies.expires_utc / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch' ) AS ExpiresUTC,
+                datetime ( cookies.last_access_utc / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch' ) AS LastAccessUTC,
                 cookies.host_key AS HostKey,
                 cookies.name AS Name,
                 cookies.path AS Path,
@@ -63,4 +63,5 @@ Queries:
 # https://forensicswiki.xyz/page/Google_Chrome
 # https://nasbench.medium.com/web-browsers-forensics-7e99940c579a
 # Use SQLECmd in conjunction with the Chrome KAPE Target: https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Browsers/Chrome.tkape
+# Please note, timestamps will be in UTC, not Local Time
 # This Map technically parses any Chromium-based Browser so the name has been changed from Chrome to Chromium as of September 2021

--- a/SQLMap/Maps/Windows_ChromiumBrowser_Downloads.smap
+++ b/SQLMap/Maps/Windows_ChromiumBrowser_Downloads.smap
@@ -2,7 +2,7 @@ Description: Chromium Browser Downloads
 Author: Andrew Rathbun, Reece394
 Email: andrew.d.rathbun@gmail.com
 Id: 0b575bcf-ade3-44e5-8162-eb52a96c2b06
-Version: 1.2
+Version: 1.3
 CSVPrefix: ChromiumBrowser
 FileName: History
 IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='urls' OR name='visits' OR name='downloads' OR name='segments' OR name='keyword_search_terms');
@@ -19,10 +19,10 @@ Queries:
                 downloads.original_mime_type AS OriginalMIMEType,
                 downloads.received_bytes AS ReceivedBytes,
                 downloads.total_bytes AS TotalBytes,
-                datetime( downloads.start_time / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch', 'localtime' ) AS StartTime,
-                datetime( downloads.end_time / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch', 'localtime' ) AS EndTime,
-                datetime( downloads.opened / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch', 'localtime' ) AS Opened,
-                datetime( downloads.last_access_time / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch', 'localtime' ) AS LastAccessTime,
+                datetime( downloads.start_time / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch' ) AS StartTime,
+                datetime( downloads.end_time / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch' ) AS EndTime,
+                datetime( downloads.opened / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch' ) AS Opened,
+                datetime( downloads.last_access_time / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch' ) AS LastAccessTime,
                 downloads.last_modified AS LastModified,
                 CASE
 
@@ -175,4 +175,5 @@ Queries:
 # https://source.chromium.org/chromium/chromium/src/+/main:components/download/public/common/download_danger_type.h
 # https://source.chromium.org/chromium/chromium/src/+/main:components/download/public/common/download_interrupt_reason_values.h
 # Use SQLECmd in conjunction with the Chrome KAPE Target: https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Browsers/Chrome.tkape
+# Please note, timestamps will be in UTC, not Local Time
 # This Map technically parses any Chromium-based Browser so the name has been changed from Chrome to Chromium as of September 2021

--- a/SQLMap/Maps/Windows_ChromiumBrowser_Favicons.smap
+++ b/SQLMap/Maps/Windows_ChromiumBrowser_Favicons.smap
@@ -2,7 +2,7 @@ Description: Chromium Browser Favicons
 Author: Andrew Rathbun
 Email: andrew.d.rathbun@gmail.com
 Id: d13f7b03-3fa3-497b-a3b7-3b7936b46ad4
-Version: 1.0
+Version: 1.1
 CSVPrefix: ChromiumBrowser
 FileName: Favicons
 IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='icon_mapping' OR name='favicons' OR name='favicon_bitmaps');
@@ -14,7 +14,7 @@ Queries:
                 SELECT
                 favicons.id AS ID,
                 favicon_bitmaps.icon_id AS IconID,
-                datetime( favicon_bitmaps.last_updated / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch', 'localtime' ) AS LastUpdated,
+                datetime( favicon_bitmaps.last_updated / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch' ) AS LastUpdated,
                 icon_mapping.page_url AS PageURL,
                 favicons.url AS FaviconURL
                 FROM
@@ -37,4 +37,5 @@ Queries:
 # https://forensicswiki.xyz/page/Google_Chrome
 # https://nasbench.medium.com/web-browsers-forensics-7e99940c579a
 # Use SQLECmd in conjunction with the Chrome KAPE Target: https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Browsers/Chrome.tkape
+# Please note, timestamps will be in UTC, not Local Time
 # This Map technically parses any Chromium-based Browser so the name has been changed from Chrome to Chromium as of September 2021

--- a/SQLMap/Maps/Windows_ChromiumBrowser_HistoryVisits.smap
+++ b/SQLMap/Maps/Windows_ChromiumBrowser_HistoryVisits.smap
@@ -2,7 +2,7 @@ Description: Chromium Browser History Visits
 Author: Andrew Rathbun
 Email: andrew.d.rathbun@gmail.com
 Id: 1f37cc07-2b10-4c80-b845-84708e4f7429
-Version: 1.2
+Version: 1.3
 CSVPrefix: ChromiumBrowser
 FileName: History
 IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='urls' OR name='visits' OR name='downloads' OR name='segments' OR name='keyword_search_terms');
@@ -13,8 +13,8 @@ Queries:
         Query: |
                 SELECT
                 urls.id AS ID,
-                datetime( visits.visit_time / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch', 'localtime' ) AS 'VisitTime (Local)',
-                datetime( urls.last_visit_time / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch', 'localtime' ) AS 'LastVisitedTime (Local)',
+                datetime( visits.visit_time / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch' ) AS 'VisitTime (UTC)',
+                datetime( urls.last_visit_time / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch' ) AS 'LastVisitedTime (UTC)',
                 urls.title AS URLTitle,
                 urls.url AS URL,
                 urls.visit_count AS VisitCount,
@@ -43,5 +43,5 @@ Queries:
 # https://forensicswiki.xyz/page/Google_Chrome
 # https://nasbench.medium.com/web-browsers-forensics-7e99940c579a
 # Use SQLECmd in conjunction with the Chrome KAPE Target: https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Browsers/Chrome.tkape
-# Please note, timestamps will be in LOCAL time, not UTC
+# Please note, timestamps will be in UTC, not Local Time
 # This Map technically parses any Chromium-based Browser so the name has been changed from Chrome to Chromium as of September 2021

--- a/SQLMap/Maps/Windows_ChromiumBrowser_KeywordSearches.smap
+++ b/SQLMap/Maps/Windows_ChromiumBrowser_KeywordSearches.smap
@@ -2,7 +2,7 @@ Description: Chromium Browser Keyword Searches
 Author: Andrew Rathbun
 Email: andrew.d.rathbun@gmail.com
 Id: d968ece4-d24a-4baf-8f07-78da07727712
-Version: 1.1
+Version: 1.2
 CSVPrefix: ChromiumBrowser
 FileName: History
 IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='urls' OR name='visits' OR name='downloads' OR name='segments' OR name='keyword_search_terms');
@@ -14,7 +14,7 @@ Queries:
                 SELECT
                 keyword_search_terms.keyword_id AS KeywordID,
                 keyword_search_terms.url_id AS URLID,
-                datetime( urls.last_visit_time / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch', 'localtime' ) AS LastVisitTime,
+                datetime( urls.last_visit_time / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch' ) AS LastVisitTime,
                 keyword_search_terms.term AS KeywordSearchTerm,
                 urls.title AS Title,
                 urls.url AS URL
@@ -32,4 +32,5 @@ Queries:
 # https://forensicswiki.xyz/page/Google_Chrome
 # https://nasbench.medium.com/web-browsers-forensics-7e99940c579a
 # Use SQLECmd in conjunction with the Chrome KAPE Target: https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Browsers/Chrome.tkape
+# Please note, timestamps will be in UTC, not Local Time
 # This Map technically parses any Chromium-based Browser so the name has been changed from Chrome to Chromium as of September 2021

--- a/SQLMap/Maps/Windows_ChromiumBrowser_OmniboxShortcuts.smap
+++ b/SQLMap/Maps/Windows_ChromiumBrowser_OmniboxShortcuts.smap
@@ -2,7 +2,7 @@ Description: Chromium Browser Omnibox Shortcuts
 Author: Andrew Rathbun
 Email: andrew.d.rathbun@gmail.com
 Id: 0e137968-371b-4078-9440-a94b3dcf0d2f
-Version: 1.0
+Version: 1.1
 CSVPrefix: ChromiumBrowser
 FileName: Shortcuts
 IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='meta' OR name='omni_box_shortcuts');
@@ -12,7 +12,7 @@ Queries:
         Name: Chromium Browser Shortcuts
         Query: |
                 SELECT
-                datetime( omni_box_shortcuts.last_access_time / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch', 'localtime' ) AS LastAccessTime,
+                datetime( omni_box_shortcuts.last_access_time / 1000000 + ( strftime( '%s', '1601-01-01' ) ), 'unixepoch' ) AS LastAccessTime,
                 omni_box_shortcuts.text AS TextTyped,
                 omni_box_shortcuts.fill_into_edit AS FillIntoEdit,
                 omni_box_shortcuts.url AS URL,
@@ -37,4 +37,5 @@ Queries:
 # https://forensicswiki.xyz/page/Google_Chrome
 # https://nasbench.medium.com/web-browsers-forensics-7e99940c579a
 # Use SQLECmd in conjunction with the Chrome KAPE Target: https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Browsers/Chrome.tkape
+# Please note, timestamps will be in UTC, not Local Time
 # This Map technically parses any Chromium-based Browser so the name has been changed from Chrome to Chromium as of September 2021


### PR DESCRIPTION
## Description

Removes conversion to Localtime and instead uses the UTC time that the Chromium date is based off. This saves confusion with other EZTools that output to UTC by default allowing for example a downloaded file to be lined up with MFTECmd without converting the timestamp first.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Map(s)
- [X] I have tested and validated that the new Map(s) work with test data and achieved the desired output
- [X] I have placed the Map(s) within the `.\SQLECmd\SQLMap\Maps` directory
- [X] I have set or updated the version of my Map(s)
- [X] I have made an attempt to document the artifacts within the Map(s)
- [X] I have consulted the [Guide](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.guide)/[Template](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
