### PR TITLE
Make Firefox Timestamps UTC

### DIFF
--- a/SQLMap/Maps/Windows_Firefox_Bookmarks.smap
+++ b/SQLMap/Maps/Windows_Firefox_Bookmarks.smap
@@ -2,7 +2,7 @@ Description: Firefox Bookmarks
 Author: Andrew Rathbun
 Email: andrew.d.rathbun@gmail.com
 Id: eda1fb9b-8275-4fb5-9ff2-ac557dc0d399
-Version: 1.1
+Version: 1.2
 CSVPrefix: Firefox
 FileName: places.sqlite
 IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='moz_historyvisits' OR name='moz_bookmarks' OR name='moz_places' OR name='moz_inputhistory');
@@ -23,8 +23,8 @@ Queries:
                 WHEN Bookmarks.type = 3 THEN
                 'Separator'
                 END AS Type,
-                datetime( Bookmarks.dateAdded / 1000000, 'unixepoch', 'localtime' ) AS DateAdded,
-                datetime( Bookmarks.lastModified / 1000000, 'unixepoch', 'localtime' ) AS LastModified,
+                datetime( Bookmarks.dateAdded / 1000000, 'unixepoch' ) AS DateAdded,
+                datetime( Bookmarks.lastModified / 1000000, 'unixepoch' ) AS LastModified,
                 Bookmarks.position AS Position,
                 Bookmarks.title AS Title,
                 moz_places.url AS URL,
@@ -46,3 +46,4 @@ Queries:
 # https://pr1malbyt3s.com/Forensics/SQLite-Browser-Artifacts.html
 # https://stackoverflow.com/questions/52343272/sql-query-on-tags-in-places-sqlite-of-firefox
 # Use SQLECmd in conjunction with the Firefox KAPE Target: https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Browsers/Firefox.tkape
+# Please note, timestamps will be in UTC, not Local Time

--- a/SQLMap/Maps/Windows_Firefox_Cookies.smap
+++ b/SQLMap/Maps/Windows_Firefox_Cookies.smap
@@ -2,7 +2,7 @@ Description: Firefox Cookies
 Author: Heather Mahalik and Andrew Rathbun
 Email: hmahalik@gmail.com, andrew.d.rathbun@gmail.com
 Id: 7be83590-8260-4c8a-9b75-c5f82290ebc2
-Version: 0.3
+Version: 0.4
 CSVPrefix: Firefox
 FileName: cookies.sqlite
 IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='moz_cookies');
@@ -16,9 +16,9 @@ Queries:
                moz_cookies.host AS Host,
                moz_cookies.name AS Name,
                moz_cookies.value AS Value,
-               datetime( moz_cookies.creationTime / 1000000, 'UNIXEPOCH', 'localtime' ) AS "Creation Time",
-               datetime( moz_cookies.lastAccessed / 1000000, 'UNIXEPOCH', 'localtime' ) AS "Last Accessed Time",
-               datetime( moz_cookies.expiry, 'UNIXEPOCH', 'localtime' ) AS Expiration,
+               datetime( moz_cookies.creationTime / 1000000, 'UNIXEPOCH' ) AS "Creation Time",
+               datetime( moz_cookies.lastAccessed / 1000000, 'UNIXEPOCH' ) AS "Last Accessed Time",
+               datetime( moz_cookies.expiry, 'UNIXEPOCH' ) AS Expiration,
                CASE
 
                WHEN moz_cookies.isSecure = 0 THEN
@@ -45,3 +45,4 @@ Queries:
 # https://pr1malbyt3s.com/Forensics/SQLite-Browser-Artifacts.html
 # https://www.digitalforensics.com/blog/an-overview-of-web-browser-forensics/
 # Use SQLECmd in conjunction with the Firefox KAPE Target: https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Browsers/Firefox.tkape
+# Please note, timestamps will be in UTC, not Local Time

--- a/SQLMap/Maps/Windows_Firefox_Downloads-Downloads.smap
+++ b/SQLMap/Maps/Windows_Firefox_Downloads-Downloads.smap
@@ -2,7 +2,7 @@ Description: Firefox Downloads - downloads.sqlite
 Author: Andrew Rathbun
 Email: andrew.d.rathbun@gmail.com
 Id: 163ac574-ab35-4509-b925-f8a14a470d4a
-Version: 1.0
+Version: 1.1
 CSVPrefix: Firefox
 FileName: downloads.sqlite
 IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='moz_downloads');
@@ -17,8 +17,8 @@ Queries:
                moz_downloads.mimeType AS MIMEType,
                moz_downloads.source AS Source,
                moz_downloads.target AS Target,
-               datetime( startTime / 1000000, 'unixepoch', 'localtime' ) AS StartTime,
-               datetime( endTime / 1000000, 'unixepoch', 'localtime' ) AS EndTime,
+               datetime( startTime / 1000000, 'unixepoch' ) AS StartTime,
+               datetime( endTime / 1000000, 'unixepoch' ) AS EndTime,
                moz_downloads.currBytes AS CurrentBytes,
                moz_downloads.maxBytes AS MaxBytes
                FROM
@@ -34,3 +34,4 @@ Queries:
 # https://davidkoepi.wordpress.com/2010/11/27/firefoxforensics/
 # https://www.sans.org/blog/firefox-3-x-forensics-using-f3e
 # Use SQLECmd in conjunction with the Firefox KAPE Target: https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Browsers/Firefox.tkape
+# Please note, timestamps will be in UTC, not Local Time

--- a/SQLMap/Maps/Windows_Firefox_Downloads-Places.smap
+++ b/SQLMap/Maps/Windows_Firefox_Downloads-Places.smap
@@ -2,7 +2,7 @@ Description: Firefox Downloads - Places.sqlite
 Author: Andrew Rathbun
 Email: andrew.d.rathbun@gmail.com
 Id: f5d66594-1b5a-45f7-8cdf-57d76d646649
-Version: 1.0
+Version: 1.1
 CSVPrefix: Firefox
 FileName: places.sqlite
 IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='moz_historyvisits' OR name='moz_bookmarks' OR name='moz_places' OR name='moz_inputhistory');
@@ -14,8 +14,8 @@ Queries:
                SELECT
                	moz_annos.place_id AS PlaceID,
                	moz_annos.content AS Content,
-               	datetime( dateAdded / 1000000, 'unixepoch', 'localtime' ) AS DateAdded,
-               	datetime( lastModified / 1000000, 'unixepoch', 'localtime' ) AS LastModified
+               	datetime( dateAdded / 1000000, 'unixepoch' ) AS DateAdded,
+               	datetime( lastModified / 1000000, 'unixepoch' ) AS LastModified
                FROM
                	moz_annos
                WHERE
@@ -32,3 +32,4 @@ Queries:
 # https://www.sans.org/blog/firefox-3-x-forensics-using-f3e
 # https://webcache.googleusercontent.com/search?q=cache:Zet3XwbInDsJ:forums.mozillazine.org/viewtopic.php%3Ff%3D7%26t%3D2688995+&cd=4&hl=en&ct=clnk&gl=us&client=firefox-b-1-d
 # Use SQLECmd in conjunction with the Firefox KAPE Target: https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Browsers/Firefox.tkape
+# Please note, timestamps will be in UTC, not Local Time

--- a/SQLMap/Maps/Windows_Firefox_Favicons.smap
+++ b/SQLMap/Maps/Windows_Firefox_Favicons.smap
@@ -2,7 +2,7 @@ Description: Firefox Favicons
 Author: Andrew Rathbun
 Email: andrew.d.rathbun@gmail.com
 Id: 3242e11b-0575-4501-862f-265e2f3fccdf
-Version: 1.0
+Version: 1.1
 CSVPrefix: Firefox
 FileName: favicons.sqlite
 IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='moz_icons' OR name='moz_icons_to_pages' OR name='moz_pages_w_icons');
@@ -15,7 +15,7 @@ Queries:
                moz_icons.id AS ID,
                moz_pages_w_icons.page_url AS PageURL,
                moz_icons.icon_url AS FaviconURL,
-               datetime( moz_icons.expire_ms / 1000, 'unixepoch', 'localtime' ) AS Expiration
+               datetime( moz_icons.expire_ms / 1000, 'unixepoch' ) AS Expiration
                FROM
                moz_icons
                INNER JOIN moz_icons_to_pages ON moz_icons.id = moz_icons_to_pages.icon_id
@@ -31,3 +31,4 @@ Queries:
 # https://davidkoepi.wordpress.com/2010/11/27/firefoxforensics/
 # https://www.sans.org/blog/firefox-3-x-forensics-using-f3e
 # Use SQLECmd in conjunction with the Firefox KAPE Target: https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Browsers/Firefox.tkape
+# Please note, timestamps will be in UTC, not Local Time

--- a/SQLMap/Maps/Windows_Firefox_FormHistory.smap
+++ b/SQLMap/Maps/Windows_Firefox_FormHistory.smap
@@ -2,7 +2,7 @@ Description: Firefox Form History database
 Author: Heather Mahalik
 Email: hmahalik@gmail.com
 Id: 928acef8-7035-45f2-b2a0-06613781c158
-Version: 0.2
+Version: 0.3
 CSVPrefix: Firefox
 FileName: formhistory.sqlite
 IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='moz_formhistory');
@@ -17,8 +17,8 @@ Queries:
                 fieldname AS FieldName,
                 value AS Value,
                 timesUsed AS TimesUsed,
-                datetime( firstUsed / 1000000, 'unixepoch', 'localtime' ) AS "First Used",
-                datetime( lastUsed / 1000000, 'unixepoch', 'localtime' ) AS "Last Used",
+                datetime( firstUsed / 1000000, 'unixepoch' ) AS "First Used",
+                datetime( lastUsed / 1000000, 'unixepoch' ) AS "Last Used",
                 guid AS GUID
                FROM
                 moz_formhistory
@@ -33,3 +33,4 @@ Queries:
 # https://pr1malbyt3s.com/Forensics/SQLite-Browser-Artifacts.html
 # https://nasbench.medium.com/web-browsers-forensics-7e99940c579a
 # Use SQLECmd in conjunction with the Firefox KAPE Target: https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Browsers/Firefox.tkape
+# Please note, timestamps will be in UTC, not Local Time

--- a/SQLMap/Maps/Windows_Firefox_History.smap
+++ b/SQLMap/Maps/Windows_Firefox_History.smap
@@ -2,7 +2,7 @@ Description: Firefox History
 Author: Andrew Rathbun
 Email: andrew.d.rathbun@gmail.com
 Id: 2f34be88-08d0-43c1-a2fd-60fe0b71f32b
-Version: 1.0
+Version: 1.1
 CSVPrefix: Firefox
 FileName: places.sqlite
 IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='moz_historyvisits' OR name='moz_bookmarks' OR name='moz_places' OR name='moz_inputhistory');
@@ -14,7 +14,7 @@ Queries:
                 SELECT
                 moz_historyvisits.id AS VisitID,
                 moz_historyvisits.from_visit AS FromVisitID,
-                datetime( moz_places.last_visit_date / 1000000, 'unixepoch', 'localtime' ) AS LastVisitDate,
+                datetime( moz_places.last_visit_date / 1000000, 'unixepoch' ) AS LastVisitDate,
                 moz_places.visit_count AS VisitCount,
                 moz_places.url AS URL,
                 moz_places.title AS Title,
@@ -74,3 +74,4 @@ Queries:
 # https://pr1malbyt3s.com/Forensics/SQLite-Browser-Artifacts.html
 # https://stackoverflow.com/questions/52343272/sql-query-on-tags-in-places-sqlite-of-firefox
 # Use SQLECmd in conjunction with the Firefox KAPE Target: https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Browsers/Firefox.tkape
+# Please note, timestamps will be in UTC, not Local Time


### PR DESCRIPTION
## Description

Following on from #91 this makes Firefox timestamps UTC by removing the conversion to Localtime.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Map(s)
- [X] I have tested and validated that the new Map(s) work with test data and achieved the desired output
- [X] I have placed the Map(s) within the `.\SQLECmd\SQLMap\Maps` directory
- [X] I have set or updated the version of my Map(s)
- [X] I have made an attempt to document the artifacts within the Map(s)
- [X] I have consulted the [Guide](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.guide)/[Template](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
