### PR TITLE
Add JSON support

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
## Description
This one has been bothering me for quite a while since it was advertised as being present but wasn't implemented. Fixes #56 
Tested with both .NET 9 Windows and Linux and seems to work well.

- Added JSON support. This outputs the results to a single file using jsonl format. Due to it being a single file for json decided to also add the map description field to make it easier to figure out what map was used.
- ~~Updated the SQLECmd.csproj to include Newtonsoft.Json package~~ Using ServiceStack.Text.Json instead
- Created a nuget.config file for package source configuration. - Needed to stop VS Code complaining about packages being missing. 

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

~- [ ] I have generated a unique `GUID` for my Map(s)~
~- [ ] I have tested and validated that the new Map(s) work with test data and achieved the desired output~
~- [ ] I have placed the Map(s) within the `.\SQLECmd\SQLMap\Maps` directory~
~- [ ] I have set or updated the version of my Map(s)~
~- [ ] I have made an attempt to document the artifacts within the Map(s)~
~- [ ] I have consulted the [Guide]~(https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.guide)/[Template](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
