### PR TITLE
Fixes Firefox places download parsing on third party browsers

### DIFF
--- a/SQLMap/Maps/Windows_Firefox_Downloads-Places.smap
+++ b/SQLMap/Maps/Windows_Firefox_Downloads-Places.smap
@@ -1,8 +1,8 @@
 Description: Firefox Downloads - Places.sqlite
-Author: Andrew Rathbun
+Author: Andrew Rathbun, Reece394
 Email: andrew.d.rathbun@gmail.com
 Id: f5d66594-1b5a-45f7-8cdf-57d76d646649
-Version: 1.1
+Version: 1.2
 CSVPrefix: Firefox
 FileName: places.sqlite
 IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='moz_historyvisits' OR name='moz_bookmarks' OR name='moz_places' OR name='moz_inputhistory');
@@ -18,8 +18,10 @@ Queries:
                	datetime( lastModified / 1000000, 'unixepoch' ) AS LastModified
                FROM
                	moz_annos
+               INNER JOIN
+               	moz_anno_attributes ON moz_annos.anno_attribute_id = moz_anno_attributes.id
                WHERE
-               	anno_attribute_id IN (1,2)
+               	moz_anno_attributes.name IN ('downloads/destinationFileURI','downloads/destinationFileName','downloads/metaData')
                ORDER BY
                	moz_annos.dateAdded ASC
         BaseFileName: Downloads-PlacesDB


### PR DESCRIPTION
## Description

On several third party Firefox based browsers as well as older versions of Firefox the attribute ids 1 and 2 are not used for downloads. Other ids observed include 4,5,6 on Comodo IceDragon and 5,6,7 on Pale Moon. This switches to using the downloads/destinationFileURI, downloads/destinationFileName and downloads/metaData names instead no longer needing to be concerned about what ids are used. This has worked for all Firefox based browsers I have tested it on and I haven't noticed any regressions.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Map(s)
- [X] I have tested and validated that the new Map(s) work with test data and achieved the desired output
- [X] I have placed the Map(s) within the `.\SQLECmd\SQLMap\Maps` directory
- [X] I have set or updated the version of my Map(s)
- [X] I have made an attempt to document the artifacts within the Map(s)
- [X] I have consulted the [Guide](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.guide)/[Template](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
