### PR TITLE
Fix Firefox History Parsing

### DIFF
--- a/SQLMap/Maps/Windows_Firefox_HistoryLegacy.smap
+++ b/SQLMap/Maps/Windows_Firefox_HistoryLegacy.smap
@@ -1,11 +1,11 @@
-Description: Firefox History
+Description: Firefox History Legacy
 Author: Andrew Rathbun, Reece394
 Email: andrew.d.rathbun@gmail.com
-Id: 2f34be88-08d0-43c1-a2fd-60fe0b71f32b
-Version: 1.2
+Id: e493912d-c5ea-47c7-b9d4-32f7e185931f
+Version: 1.0
 CSVPrefix: Firefox
 FileName: places.sqlite
-IdentifyQuery: SELECT (SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND (name='moz_historyvisits' OR name='moz_bookmarks' OR name='moz_places' OR name='moz_inputhistory')) + (SELECT CASE WHEN (SELECT COUNT(*) FROM pragma_table_info('moz_places') WHERE name IN ('description','preview_image_url')) > 1 THEN 1 ELSE 0 END);
+IdentifyQuery: SELECT (SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND (name='moz_historyvisits' OR name='moz_bookmarks' OR name='moz_places' OR name='moz_inputhistory')) + (SELECT CASE WHEN (SELECT COUNT(*) FROM pragma_table_info('moz_places') WHERE name IN ('description','preview_image_url')) > 1 THEN 0 ELSE 1 END);
 IdentifyValue: 5
 Queries:
     -
@@ -19,7 +19,6 @@ Queries:
                 moz_places.visit_count AS VisitCount,
                 moz_places.url AS URL,
                 moz_places.title AS Title,
-                moz_places.description AS Description,
                 CASE
 
                 WHEN moz_historyvisits.visit_type = 1 THEN
@@ -55,8 +54,7 @@ Queries:
                 WHEN moz_places.typed = 1 THEN
                 'Yes'
                 END AS Typed,
-                moz_places.frecency AS Frecency,
-                moz_places.preview_image_url AS PreviewImageURL
+                moz_places.frecency AS Frecency
                 FROM
                 moz_places
                 INNER JOIN moz_historyvisits ON moz_places.id = moz_historyvisits.place_id


### PR DESCRIPTION
## Description

Fixes Firefox history parsing by changing the join id from moz_places.origin_id and moz_historyvisits.id to moz_places.id and moz_historyvisits.place_id. 

Additionally adds moz_historyvisits.visit_date which displays the unique visit date of each site every time it is visited rather than just the last visited timestamp. This also sorts by this field but retains the last visited timestamp as this is useful if a site is visited multiple times.

Also adds a Firefox History Legacy map which is functionally identical but drops the description and preview_image_url fields as several third party browsers as well as older Firefox versions do not have these fields and result in failure to parse otherwise. This also modifies the identify query to gate based on if these fields exist or not. This means there will only be one output rather than potentially two of the same database.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Map(s)
- [X] I have tested and validated that the new Map(s) work with test data and achieved the desired output
- [X] I have placed the Map(s) within the `.\SQLECmd\SQLMap\Maps` directory
- [X] I have set or updated the version of my Map(s)
- [X] I have made an attempt to document the artifacts within the Map(s)
- [X] I have consulted the [Guide](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.guide)/[Template](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
