### PR TITLE
Add URL and Attribute Type to Firefox places download map

### DIFF
--- a/SQLMap/Maps/Windows_Firefox_Downloads-Places.smap
+++ b/SQLMap/Maps/Windows_Firefox_Downloads-Places.smap
@@ -2,7 +2,7 @@ Description: Firefox Downloads - Places.sqlite
 Author: Andrew Rathbun, Reece394
 Email: andrew.d.rathbun@gmail.com
 Id: f5d66594-1b5a-45f7-8cdf-57d76d646649
-Version: 1.2
+Version: 1.3
 CSVPrefix: Firefox
 FileName: places.sqlite
 IdentifyQuery: SELECT count(*) FROM sqlite_master WHERE type='table' AND (name='moz_historyvisits' OR name='moz_bookmarks' OR name='moz_places' OR name='moz_inputhistory');
@@ -13,13 +13,25 @@ Queries:
         Query: |
                SELECT
                	moz_annos.place_id AS PlaceID,
+               	moz_places.url AS URL,
                	moz_annos.content AS Content,
+                CASE
+
+                WHEN moz_anno_attributes.name = 'downloads/destinationFileURI' THEN
+                'FileURI'
+                WHEN moz_anno_attributes.name = 'downloads/destinationFileName' THEN
+                'Filename'
+                WHEN moz_anno_attributes.name = 'downloads/metaData' THEN
+                'Metadata'
+                END AS Type,
                	datetime( dateAdded / 1000000, 'unixepoch' ) AS DateAdded,
                	datetime( lastModified / 1000000, 'unixepoch' ) AS LastModified
                FROM
                	moz_annos
                INNER JOIN
                	moz_anno_attributes ON moz_annos.anno_attribute_id = moz_anno_attributes.id
+               INNER JOIN
+               	moz_places ON moz_places.id = moz_annos.place_id
                WHERE
                	moz_anno_attributes.name IN ('downloads/destinationFileURI','downloads/destinationFileName','downloads/metaData')
                ORDER BY


### PR DESCRIPTION
## Description

This adds the URL field to the Firefox places download map to save time having to cross-reference the database for the places id. It also adds an attribute type field to allow filtering out of field types if needed.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Map(s)
- [X] I have tested and validated that the new Map(s) work with test data and achieved the desired output
- [X] I have placed the Map(s) within the `.\SQLECmd\SQLMap\Maps` directory
- [X] I have set or updated the version of my Map(s)
- [X] I have made an attempt to document the artifacts within the Map(s)
- [X] I have consulted the [Guide](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.guide)/[Template](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/!OS_Application_OptionalDescription.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
