### PR TITLE
Use default TLS validation for sync downloads

### DIFF
--- a/SQLECmd/Program.cs
+++ b/SQLECmd/Program.cs
@@ -849,11 +849,8 @@ internal class Program
         }
 
 
-        using (var handler = new HttpClientHandler())
+        using (var client = new HttpClient())
         {
-            handler.ServerCertificateCustomValidationCallback = (message, certificate, chain, sslPolicyErrors) => true;
-            var client = new HttpClient(handler);
-
             try
             {
                 var response = await client.GetAsync("https://github.com/EricZimmerman/SQLECmd/archive/master.zip");


### PR DESCRIPTION
## Summary

- Remove the custom certificate validation callback from SQLECmd's `--sync` download path.
- Let `HttpClient` use the platform's default TLS certificate validation when downloading the GitHub map archive.

## Rationale

`--sync` downloads the SQLECmd map archive from GitHub and installs updated maps into the local `Maps` directory. The previous custom validation callback accepted all server certificates, bypassing normal hostname and certificate-chain validation.

Using the default `HttpClient` behavior preserves the existing sync flow while allowing invalid TLS certificates to be rejected.